### PR TITLE
Fix failure to save metadata.

### DIFF
--- a/lib/commons/odata/ODataClient.js
+++ b/lib/commons/odata/ODataClient.js
@@ -31,6 +31,7 @@ module.exports = class ODataClient {
       method: 'GET'
     });
     const jsonSchemaDescription = jsonSchemaGenerator(sampleDocument.value[0]);
+    delete jsonSchemaDescription['$schema'];
     delete jsonSchemaDescription.properties['@odata.etag'];
     const guessedKeyName = `${entityType.replace(/s$/, '')}id`;
     Object.keys(jsonSchemaDescription.properties).forEach(prop => {


### PR DESCRIPTION
Fixes bug that @stas-fomenko found.

Caused because our platform seems to reject the `$schema` property of JSONSchema even though it is part of the JSONSchema spec.